### PR TITLE
Survey view responsive

### DIFF
--- a/public/css/surveyViewStyles.css
+++ b/public/css/surveyViewStyles.css
@@ -173,7 +173,7 @@ and also iPads specifically.
 
 
     .table-responsive-custom {
-        width: 90vw;
+        width: 100%;
     }
 
     /* Force table to not be like tables anymore */

--- a/public/css/surveyViewStyles.css
+++ b/public/css/surveyViewStyles.css
@@ -166,9 +166,7 @@ Max width before this PARTICULAR table gets nasty
 This query will take effect for any screen smaller than 760px
 and also iPads specifically.
 */
-@media
-only screen and (max-width: 1024px),
-(min-device-width: 768px) and (max-device-width: 1024px)  {
+@media screen and (max-width: 978px) {
     #survey-answer tr:nth-of-type(even){
         background-color: white;
     }


### PR DESCRIPTION
Fix following bug: 

View was "untidy", when the view width was between mobile and desktop device.   